### PR TITLE
Cambios menores en el sitio web

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,7 +20,7 @@ description: > # this means to ignore newlines until "baseurl:"
   técnico de los profesionales del área TI, mediante meetups y eventos de desarrolladores
   para desarrolladores en La Serena, Coquimbo y sus alrededores.
 baseurl: "" # the subpath of your site, e.g. /blog
-url: "http://127.0.0.1:4000" # the base hostname & protocol for your site
+url: "http://ivdevs.com" # the base hostname & protocol for your site
 twitter_username: iv_devs
 github_username:  iv-devs
 design_username: rocket4ce

--- a/prensa.html
+++ b/prensa.html
@@ -60,6 +60,8 @@ permalink: /prensa/
                     <li><code><time datetime="2016-08-08">08-08-2016</time>:</code> <a href="/assets/audio/Entrevista_Duenos_De_La_Tarde.m4a" target="_blank">Nota [Radio Montecarlo] - Los Dueños de la tarde</a></li>
 
                     <li><code><time datetime="2016-05-21">21-05-2016</time>:</code> <a href="http://www.guillermodiaz.com/2016/05/la-region-de-gabriela-mistral/" target="_blank">Blog - La región de Gabriela Mistral</a></li>
+
+                    <li><code><time datatime="2016-12-17">17-12-2016</time>:</code> <a href="http://enlinea.santotomas.cl/actualidad-institucional/mundo-santo-ctomas/alumnos-analista-programador-participaron-curso-basico-git/37491/" target="_blank">Nota [santotomas.cl] - Curso de git a Analistas Programadores del Santo Tomás de Ovalle</a></li>
                 </ul>
             </p>
 

--- a/prensa.html
+++ b/prensa.html
@@ -51,6 +51,8 @@ permalink: /prensa/
                 <p>A lo largo del camino que estamos recorriendo juntos, hemos sido nombrados, comentados en algún sitio distinto al nuestro. esta sección recopila esas notas de prensa en las cuales <code>IV Devs</code> ha sido nombrado</p>
 
                 <ul>
+                    <li><code><time datatime="2016-12-17">17-12-2016</time>:</code> <a href="http://enlinea.santotomas.cl/actualidad-institucional/mundo-santo-ctomas/alumnos-analista-programador-participaron-curso-basico-git/37491/" target="_blank">Nota [santotomas.cl] - Curso de git a Analistas Programadores del Santo Tomás de Ovalle</a></li>
+                    
                     <li><code><time datetime="2016-08-15">15-08-2016</time>:</code> <a href="/assets/docs/eldia_pag14.pdf" target="_blank">Nota [diarioeldia.cl] - Exitosa maratón tecnológica en La Serena puso el foco en la innovación</a></li>
 
                     <li><code><time datetime="2016-08-10 17:08:01">10-08-2016</time>:</code> <a href="http://www.elobservatodo.cl/noticia/emprendimiento-regional/hackaton-pretende-reunir-mas-de-100-personas-en-la-serena-0" target="_blank">Nota [elobservatodo.cl] - Hackatón pretende reunir a más de 100 personas en La Serena</a></li>
@@ -60,8 +62,6 @@ permalink: /prensa/
                     <li><code><time datetime="2016-08-08">08-08-2016</time>:</code> <a href="/assets/audio/Entrevista_Duenos_De_La_Tarde.m4a" target="_blank">Nota [Radio Montecarlo] - Los Dueños de la tarde</a></li>
 
                     <li><code><time datetime="2016-05-21">21-05-2016</time>:</code> <a href="http://www.guillermodiaz.com/2016/05/la-region-de-gabriela-mistral/" target="_blank">Blog - La región de Gabriela Mistral</a></li>
-
-                    <li><code><time datatime="2016-12-17">17-12-2016</time>:</code> <a href="http://enlinea.santotomas.cl/actualidad-institucional/mundo-santo-ctomas/alumnos-analista-programador-participaron-curso-basico-git/37491/" target="_blank">Nota [santotomas.cl] - Curso de git a Analistas Programadores del Santo Tomás de Ovalle</a></li>
                 </ul>
             </p>
 


### PR DESCRIPTION
1.- Agregue un enlace nuevo en la pestaña de prensa direccionando a la pagina de santo tomas donde indican el curso de git realizado en diciembre del 2016.

2.- Modifique el url encontrado en _config.yml, ya que por defecto venia como 127.0.0.1:4000 y este no dejaba funcionar en los metadatos.